### PR TITLE
Improvements to simulation visualization and camera sensor parameters

### DIFF
--- a/models/sonar/model.sdf
+++ b/models/sonar/model.sdf
@@ -39,7 +39,7 @@
         </plugin>
         <always_on>1</always_on>
         <update_rate>20</update_rate>
-        <visualize>true</visualize>
+        <visualize>false</visualize>
       </sensor>
     </link>
   </model>

--- a/models/typhoon_h480/typhoon_h480.sdf.jinja
+++ b/models/typhoon_h480/typhoon_h480.sdf.jinja
@@ -401,7 +401,7 @@
         </camera>
         <always_on>1</always_on>
         <update_rate>10</update_rate>
-        <visualize>true</visualize>
+        <visualize>false</visualize>
         <plugin name="GstCameraPlugin" filename="libgazebo_gst_camera_plugin.so">
             <robotNamespace></robotNamespace>
             <udpHost>127.0.0.1</udpHost>

--- a/models/typhoon_h480/typhoon_h480.sdf.jinja
+++ b/models/typhoon_h480/typhoon_h480.sdf.jinja
@@ -329,6 +329,7 @@
     </joint>
 
     <link name="cgo3_camera_link">
+      <gravity>0</gravity>
       <inertial>
         <!-- place holder -->
         <pose>-0.041 0 -0.162 0 0 0</pose>

--- a/models/typhoon_h480/typhoon_h480.sdf.jinja
+++ b/models/typhoon_h480/typhoon_h480.sdf.jinja
@@ -391,8 +391,8 @@
           <horizontal_fov>2.0</horizontal_fov>
           <image>
             <format>R8G8B8</format>
-            <width>640</width>
-            <height>360</height>
+            <width>3840</width>
+            <height>2160</height>
           </image>
           <clip>
             <near>0.05</near>
@@ -412,7 +412,7 @@
             <interval>1</interval>
             <vendor>Yuneec</vendor>
             <model>CGO3</model>
-            <focal_length>2.44</focal_length>
+            <focal_length>14</focal_length>
             <sensor_size_h>6.17</sensor_size_h>
             <sensor_size_v>4.55</sensor_size_v>
             <width>3840</width>


### PR DESCRIPTION
**Description**
<!--- Creating a pull request allows you to merge code from a separate branch, usually to the main branch. -->
<!--- Make sure to link the issue you are fixing with this Pull Request using the "Linked Issues" dropdown on the right panel. -->
Removed some unnecessary visualization in gazebo simulation:
- Removed blue sonar visualization cone
- Removed camera visualization cone

Removed gravity from Typhoon H480's camera link which was causing issues for Gimbal control, per issue: https://github.com/Airtonomy/flight-sdk-ros/issues/398

Updated Typhoon H480's camera sensor parameters to improve resolution of photos captured.

**Additional context**
It was recommended that we update the camera sensor parameters to match DJI's camera parameters. This is because the oil tank routine has hard coded values for the DJI camera. However I chose to keep it as the intended simulated camera ([Yuneec CGO3](https://www.bhphotovideo.com/c/product/1223034-REG/yuneec_yuncgo3us_cgo3_4k_3_axis_gimbal.html/specs)) parameters. Instead, we'll remove the hard coded values in flight oil tank and add in an function in the camera api in flight-sdk-ros to perform camera-related calculations instead. This is addressed in https://github.com/Airtonomy/flight-sdk-ros/issues/413
